### PR TITLE
Create a snippet that demonstrates extending a native element (fixes #29)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ See the [contribution guide](CONTRIBUTING.md).
 - [Finding Shadow DOM elements](snippets/basics/finding-shadow-dom-elements.html)
 - [Using a computed property](snippets/basics/using-a-computed-property.html)
 - [Creating a one-time binding](snippets/basics/creating-a-one-time-binding.html)
+- [Extending a native HTML element](snippets/basics/extending-a-native-element.html)
 
 ### Control Flow
 

--- a/snippets/basics/extending-a-native-element.html
+++ b/snippets/basics/extending-a-native-element.html
@@ -1,0 +1,83 @@
+<!--
+Copyright (c) 2014 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+
+<!--
+# Extending a native HTML element
+
+Shows how to add new behaviour and style to a native HTML element
+
+When extending a native element you must use the `is` attribute, like
+`<button is="icon-button">`, not `<icon-button>`. An element that extends a
+native element in this way is called a **type extension**, and inherits the
+prototype and DOM of the parent.
+
+There are issues in current browser versions that prevent creating a new Shadow
+DOM for many types of element, so you cannot use a `<template>` in your extended
+element. In Chrome this list currently includes 'img', 'textarea', 'select',
+'canvas', and more. The full list can be seen in [the Chrome issue tracker](https://code.google.com/p/chromium/issues/detail?id=234020).
+
+[jsbin](http://jsbin.com/zesaqeruyo/1/)
+-->
+<link rel="import" href="../../components/polymer/polymer.html">
+
+<!--
+A simple element that extends the Shadow DOM of a button element to include an
+image provided in the src atttribute. It also demonstrates overriding the
+default style of the extended element.
+-->
+<polymer-element name="icon-button" attributes="src" extends="button" noscript>
+  <template>
+    <style>
+      :host * {
+        vertical-align: middle;
+      }
+      :host {
+        height: 50px;
+        padding: 10px;
+        background-color: #eeee55;
+        border: 2px solid orange;
+        border-radius: 10px;
+      }
+      img {
+        margin-right: 10px;
+      }
+    </style>
+    <img src="{{src}}"/>
+    <content></content>
+  </template>
+</polymer-element>
+
+<!--
+Extending the behavior of the native anchor element to pre-fetch the URL on
+hover.
+-->
+<polymer-element name="hover-prefetch" extends="a" on-mouseover="prefetch">
+  <script>
+    Polymer({
+      requested: false,
+      prefetch: function() {
+        if (this.requested) {
+          return;
+        }
+
+        // Load the page and all of it's resources in a hidden IFrame.
+        var iframe = document.createElement('iframe');
+        iframe.style.visibility = 'hidden';
+        iframe.style.position = 'absolute';
+        iframe.src = this.href;
+        iframe.id = this.href;
+
+        // Append the IFrame to the DOM.
+        document.body.insertBefore(iframe, document.body.firstChild);
+
+        this.requested = true;
+      }
+    });
+  </script>
+</polymer-element>

--- a/tests/all.html
+++ b/tests/all.html
@@ -22,6 +22,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     htmlTest('basics/finding-shadow-dom-elements.html');
     htmlTest('basics/using-a-computed-property.html');
     htmlTest('basics/creating-a-one-time-binding.html');
+    htmlTest('basics/extending-a-native-element.html');
     htmlTest('basics/dynamically-adding-a-custom-element-to-the-dom.html');
   });
 

--- a/tests/basics/extending-a-native-element.html
+++ b/tests/basics/extending-a-native-element.html
@@ -1,0 +1,45 @@
+<!doctype html>
+<!--
+Copyright (c) 2014 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Extending a native element</title>
+  <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+  <script src="../../components/platform/platform.js"></script>
+  <link rel="import" href="../../components/polymer-test-tools/tools.html">
+  <script src="../../components/polymer-test-tools/htmltest.js"></script>
+  <link rel="import" href="../../snippets/basics/extending-a-native-element.html">
+</head>
+<body>
+  <button is="icon-button" src="http://www.polymer-project.org/images/icons/android.svg"></button>
+  <a is="hover-prefetch" href="http://www.polymer-project.org/"></a>
+<script>
+  document.addEventListener('polymer-ready', function() {
+    var el1 = document.querySelector('[is=icon-button]');
+    var el2 = document.querySelector('[is=hover-prefetch]');
+
+    var icon = el1.shadowRoot.querySelector('img');
+    assert.equal(icon.src, el1.src);
+    assert.equal(getComputedStyle(el1).backgroundColor, 'rgb(238, 238, 85)');
+
+    var iframes = document.querySelectorAll('iframe');
+    assert.equal(iframes.length, 0);
+    el2.dispatchEvent(new Event('mouseover'));
+
+    setTimeout(function() {
+      iframes = document.querySelectorAll('iframe');
+      assert.equal(iframes.length, 1);
+      assert.equal(iframes[0].id, el2.href);
+      done();
+    }, 0);
+  });
+</script>
+</body>
+</html>


### PR DESCRIPTION
The samples were trickier and less exciting than I thought they would be. There is a set of bugs (https://code.google.com/p/chromium/issues/detail?id=234020) in Chrome that mean that you can't extend the Shadow DOM of most of the interesting native elements.
